### PR TITLE
Add a middleware for giving a user a UUID

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ rvm:
   - 2.1.5
   - 2.2.0
   - jruby-19mode
+  - rbx-2
 env:
   - USE_SIMPLECOV=true CODECLIMATE_REPO_TOKEN=2175628fb41494d45b50b6938600a53c130e1f7ac3b81b072bb71e91073a5e4a

--- a/lib/macmillan/utils/middleware.rb
+++ b/lib/macmillan/utils/middleware.rb
@@ -2,6 +2,7 @@ module Macmillan
   module Utils
     module Middleware
       autoload :WeakEtags, 'macmillan/utils/middleware/weak_etags'
+      autoload :Uuid,      'macmillan/utils/middleware/uuid'
     end
   end
 end

--- a/lib/macmillan/utils/middleware/uuid.rb
+++ b/lib/macmillan/utils/middleware/uuid.rb
@@ -1,0 +1,89 @@
+module Macmillan
+  module Utils
+    module Middleware
+      ##
+      # Rack Middleware for uniquley identifying a user.
+      #
+      # If the user is logged in, their UUID will be based upon their user_id, otherwise
+      # it will be randomly generated.  This UUID will be stored in the rack env, and
+      # persisted in a cookie.
+      #
+      # This middleware expects a user object to be stored in the rack env.
+      #
+      class Uuid
+        def self.env_key
+          'user.uuid'
+        end
+
+        def initialize(app, opts={})
+          @app            = app
+          @user_env_key   = opts[:user_env_key] || 'current_user'
+          @user_id_method = opts[:user_id_method] || 'user_id'
+        end
+
+        class CallHandler
+          attr_reader :app, :request, :user_env_key, :user_id_method, :cookie_key
+
+          def initialize(env, app, user_env_key, user_id_method, cookie_key)
+            @app            = app
+            @request        = Rack::Request.new(env)
+            @user_env_key   = user_env_key
+            @user_id_method = user_id_method
+            @cookie_key     = cookie_key
+
+            env[cookie_key] = user_uuid
+          end
+
+          def response
+            @response ||= begin
+                            status, headers, body = app.call(request.env)
+                            Rack::Response.new(body, status, headers)
+                          end
+          end
+
+          def finish
+            save_cookie if store_cookie?
+            response.finish
+          end
+
+          def user
+            request.env[user_env_key]
+          end
+
+          def user_uuid
+            @user_uuid ||= begin
+                             if user
+                               Digest::SHA1.hexdigest(user.public_send(user_id_method).to_s)
+                             elsif cookie_uuid
+                               cookie_uuid
+                             else
+                               SecureRandom.uuid
+                             end
+                           end
+          end
+
+          def cookie_uuid
+            request.cookies[cookie_key]
+          end
+
+          def store_cookie?
+            user_uuid != cookie_uuid
+          end
+
+          def save_cookie
+            response.set_cookie(cookie_key, { value: user_uuid, path: '/', expires: DateTime.now.next_year.to_time })
+          end
+        end
+
+        def call(env)
+          dup.process(env)
+        end
+
+        def process(env)
+          handler = CallHandler.new(env, @app, @user_env_key, @user_id_method, self.class.env_key)
+          handler.finish
+        end
+      end
+    end
+  end
+end

--- a/lib/macmillan/utils/middleware/weak_etags.rb
+++ b/lib/macmillan/utils/middleware/weak_etags.rb
@@ -24,8 +24,7 @@ module Macmillan
             env['HTTP_IF_NONE_MATCH'] = etag.gsub(/^W\//, '')
           end
 
-          status, headers, body = @app.call(env)
-          [status, headers, body]
+          @app.call(env)
         end
       end
     end

--- a/spec/lib/macmillan/utils/middleware/uuid_spec.rb
+++ b/spec/lib/macmillan/utils/middleware/uuid_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+RSpec.describe Macmillan::Utils::Middleware::Uuid do
+  let(:app)             { ->(env) { [200, env, 'app'] } }
+  let(:request)         { req_for('http://example.com') }
+  let(:user)            { double(email: 'bob.flemming@cough.com', user_id: '12345') }
+  let(:user_uuid)       { Digest::SHA1.hexdigest(user.user_id.to_s) }
+
+  subject { Macmillan::Utils::Middleware::Uuid.new(app) }
+
+  context 'when we have a logged in user' do
+    before do
+      request.env['current_user'] = user
+    end
+
+    context 'who has not visited before' do
+      it 'sets the user_uuid cookie' do
+        _status, headers, _body = subject.call(request.env)
+        expect(headers['Set-Cookie']).to include(user_uuid)
+      end
+
+      it 'stores the user_uuid in the env' do
+        _status, headers, _body = subject.call(request.env)
+        expect(headers['user.uuid']).to eq(user_uuid)
+      end
+    end
+
+    context 'who also has a randomly assigned user_uuid cookie (from a previous non-authenticated session)' do
+      before do
+        request.cookies['user.uuid'] = 'qwerty'
+      end
+
+      it 'replaces this cookie with one based on the users user_id' do
+        _status, headers, _body = subject.call(request.env)
+        expect(headers['Set-Cookie']).to include("user.uuid=#{user_uuid}")
+      end
+    end
+  end
+
+  context 'when we have a non-logged in user' do
+    before do
+      request.env['current_user'] = nil
+      allow(SecureRandom).to receive(:uuid).and_return('wibble')
+    end
+
+    context 'who has not visited before' do
+      it 'stores the auto-generated UUID in the env' do
+        _status, headers, _body = subject.call(request.env)
+        expect(headers['user.uuid']).to eq('wibble')
+      end
+
+      it 'sets the user_uuid cookie' do
+        _status, headers, _body = subject.call(request.env)
+        expect(headers['Set-Cookie']).to include('user.uuid=wibble')
+      end
+    end
+
+    context 'who has visited before and has a user_uuid cookie' do
+      before do
+        request.cookies['user.uuid'] = 'qwerty'
+      end
+
+      it 'stores the user_uuid (from the cookie) in the env' do
+        _status, headers, _body = subject.call(request.env)
+        expect(headers['user.uuid']).to eq('qwerty')
+      end
+
+      it 'does not try to replace the cookie' do
+        _status, headers, _body = subject.call(request.env)
+        expect(headers['Set-Cookie']).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
We’re using code similar to this in multiple places/apps - we should move to use just this one implementation and cookie.