### PR TITLE
Rspec matcher to validate mojson output

### DIFF
--- a/lib/macmillan/utils/rspec/matchers/be_valid_mosaic.rb
+++ b/lib/macmillan/utils/rspec/matchers/be_valid_mosaic.rb
@@ -22,16 +22,10 @@ RSpec::Matchers.define :be_valid_mosaic do
 
   def output
     @output ||= begin
-      file = Tempfile.open(["mojson_output", '.json'])
-      file.write(actual)
-      file.close
-      JSON.parse(`mojson -f #{file.path} --reporter json`)
+      JSON.parse(`echo #{actual.to_json} | mojson --reporter json`)
     rescue Errno::ENOENT
       raise 'Error be_valid_mosaic requires mojson binary' \
       'see: https://github.com/nature/mosaic-json'
-    ensure
-      file.close
-      file.unlink
     end
   end
 

--- a/lib/macmillan/utils/rspec/matchers/be_valid_mosaic.rb
+++ b/lib/macmillan/utils/rspec/matchers/be_valid_mosaic.rb
@@ -1,0 +1,43 @@
+require 'rspec/expectations'
+
+### Example:
+### it { is_expected.to be_valid_mosaic }
+#
+### example output:
+#
+### Failure/Error: it { is_expected.to be_valid_mosaic }
+### Missing required property: template in /layout
+
+RSpec::Matchers.define :be_valid_mosaic do
+  match do |actual|
+    output.map {|context| context.fetch("data", {}).fetch("errors")}.flatten.empty?
+  end
+  failure_message do |actual|
+    output.map do |context|
+      "#{error_msg(context)}"
+    end.join("\n")
+  end
+
+  private
+
+  def output
+    @output ||= begin
+      file = Tempfile.open(["mojson_output", '.json'])
+      file.write(actual)
+      file.close
+      JSON.parse(`mojson -f #{file.path} --reporter json`)
+    rescue Errno::ENOENT
+      raise 'Error be_valid_mosaic requires mojson binary' \
+      'see: https://github.com/nature/mosaic-json'
+    ensure
+      file.close
+      file.unlink
+    end
+  end
+
+  def error_msg(context)
+    context.fetch("data", {}).fetch("errors", []).map do |error|
+      "#{error['message']} in #{error['dataPath']}"
+    end.join("\n")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ Bundler.setup(:default, :test)
 
 require 'macmillan/utils/rspec/rspec_defaults'
 require 'macmillan/utils/rspec/rack_test_helper'
+require 'macmillan/utils/rspec/matchers/be_valid_mosaic'
 require 'macmillan/utils/test_helpers/simplecov_helper'
 
 require 'pry'


### PR DESCRIPTION
Depends on having mojson

just require 'macmillan/utils/rspec/matchers/be_valid_mosaic' in your spec_helper