### PR TITLE
Settings::Lookup shouldn't blow up on falsey values

### DIFF
--- a/lib/macmillan/utils/settings/lookup.rb
+++ b/lib/macmillan/utils/settings/lookup.rb
@@ -7,17 +7,12 @@ module Macmillan
         end
 
         def lookup(key)
-          value = nil
-
           @backends.each do |backend|
-            break if value
             result = backend.get(key)
-            value  = result.value unless result.is_a?(KeyNotFound)
+            return result.value unless result.is_a?(KeyNotFound)
           end
 
-          fail KeyNotFoundError.new("Cannot find a settings value for #{key}") unless value
-
-          value
+          fail KeyNotFoundError.new("Cannot find a settings value for #{key}")
         end
 
         # Backwards compatibility: in the past this has been used like a Hash

--- a/spec/lib/macmillan/utils/logger/factory_spec.rb
+++ b/spec/lib/macmillan/utils/logger/factory_spec.rb
@@ -32,7 +32,9 @@ describe Macmillan::Utils::Logger::Factory do
       end
 
       it 'allows you to configure the log target' do
-        expect(Logger).to receive(:new).with('foo.log').and_call_original
+        logger = double('logger').as_null_object
+        expect(Logger).to receive(:new).with('foo.log').and_return(logger)
+
         Macmillan::Utils::Logger::Factory.build_logger(:logger, target: 'foo.log')
       end
     end

--- a/spec/lib/macmillan/utils/settings/lookup_spec.rb
+++ b/spec/lib/macmillan/utils/settings/lookup_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Macmillan::Utils::Settings::Lookup do
+  let(:backend1) { double('Backend One') }
+  let(:backend2) { double('Backend Two') }
+
+  subject { described_class.new([backend1, backend2]) }
+
+  it 'returns the first value it finds' do
+    true_value = Macmillan::Utils::Settings::Value.new('is_craigw_trolling_us', true, backend1, 'is_craigw_trolling_us')
+    allow(backend1).to receive(:get).with('is_craigw_trolling_us').and_return(true_value)
+
+    expect(backend2).to_not receive(:get)
+    expect(subject.lookup('is_craigw_trolling_us')).to eq(true)
+  end
+
+  it 'tries successive backends' do
+    not_found_value = Macmillan::Utils::Settings::KeyNotFound.new('is_craigw_trolling_us', backend1, 'is_craigw_trolling_us')
+    true_value = Macmillan::Utils::Settings::Value.new('is_craigw_trolling_us', true, backend2, 'is_craigw_trolling_us')
+
+    allow(backend1).to receive(:get).with('is_craigw_trolling_us').and_return(not_found_value)
+    allow(backend2).to receive(:get).with('is_craigw_trolling_us').and_return(true_value)
+
+    expect(subject.lookup('is_craigw_trolling_us')).to eq(true)
+  end
+
+  it 'returns a falsey value if it is actually set' do
+    not_found_value = Macmillan::Utils::Settings::KeyNotFound.new('is_it_good_code', backend1, 'is_it_good_code')
+    false_value = Macmillan::Utils::Settings::Value.new('is_it_good_code', false, backend2, 'is_it_good_code')
+
+    allow(backend1).to receive(:get).with('is_it_good_code').and_return(not_found_value)
+    allow(backend2).to receive(:get).with('is_it_good_code').and_return(false_value)
+
+    expect(subject.lookup('is_it_good_code')).to eq(false)
+  end
+
+  it 'raises an error if it cannot find a value in any backend' do
+    not_found_value1 = Macmillan::Utils::Settings::KeyNotFound.new('not_found', backend1, 'not_found')
+    not_found_value2 = Macmillan::Utils::Settings::KeyNotFound.new('not_found', backend2, 'not_found')
+
+    allow(backend1).to receive(:get).with('not_found').and_return(not_found_value1)
+    allow(backend2).to receive(:get).with('not_found').and_return(not_found_value2)
+
+    expect { subject.lookup('not_found') }.to raise_error(Macmillan::Utils::Settings::KeyNotFoundError)
+  end
+end


### PR DESCRIPTION
Whenever a settings value was (explicitly) set to `false` or `nil`, Settings::Lookup would fail with a KeyNotFound error due to it wrongly checking for a value with:

```ruby
fail KeyNotFoundError.new("Cannot find a settings value for #{key}") unless value
```

Also fixes an issue where running the test suite would create a `foo.log` file on the filesystem.